### PR TITLE
Handle auth token in local and session storage

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -17,7 +17,12 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001/a
 
 class ApiClient {
   private getAuthHeaders() {
-    const token = typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null;
+    let token: string | null = null;
+    if (typeof window !== 'undefined') {
+      token =
+        localStorage.getItem('auth_token') ??
+        sessionStorage.getItem('auth_token');
+    }
     return {
       'Content-Type': 'application/json',
       ...(token && { Authorization: `Bearer ${token}` }),


### PR DESCRIPTION
## Summary
- Read auth_token from localStorage, falling back to sessionStorage
- Ensure Authorization header includes token from either storage

## Testing
- `node -e "const { apiClient } = require('./tmp/api.js')"` etc ??? wait we already removed tmp.


------
https://chatgpt.com/codex/tasks/task_e_689a31c8b32c83249b177beeee780968